### PR TITLE
Allow meta tags to support dynamic url attributes.

### DIFF
--- a/core-ng/src/main/java/core/framework/impl/template/node/Attribute.java
+++ b/core-ng/src/main/java/core/framework/impl/template/node/Attribute.java
@@ -56,6 +56,11 @@ public class Attribute {
             || "c:defer".equals(name);
     }
 
+    boolean isDynamicMetaAttribute() {
+        return "meta".equals(tagName) && ("c:content".equals(name) || "content".equals(name))
+                || "meta".equals(tagName) && ("c:href".equals(name) || "href".equals(name));
+    }
+
     void addBooleanAttribute(ContainerFragment parent, TemplateMetaContext context) {
         parent.add(new BooleanAttributeFragment(name.substring(2), value, context, location));
     }
@@ -83,6 +88,21 @@ public class Attribute {
             } else {
                 addStaticContent(parent);
             }
+        }
+    }
+
+    void addMetaAttribute(ContainerFragment parent, TemplateMetaContext context) {
+        parent.addStaticContent(" ");
+
+        if ("c:href".equals(name)) { // intended to put an url, replace name with content so it works
+            parent.addStaticContent("content");
+            parent.addStaticContent("=");
+            parent.add(new URLFragment(value, context, false, location));
+        } else {
+            parent.addStaticContent(name.substring(2));
+            parent.addStaticContent("=\"");
+            parent.add(new TextContentFragment(value, context, location));
+            parent.addStaticContent("\"");
         }
     }
 

--- a/core-ng/src/main/java/core/framework/impl/template/node/Attributes.java
+++ b/core-ng/src/main/java/core/framework/impl/template/node/Attributes.java
@@ -4,7 +4,6 @@ import core.framework.api.util.Exceptions;
 import core.framework.api.util.Maps;
 import core.framework.impl.template.TemplateMetaContext;
 import core.framework.impl.template.fragment.ContainerFragment;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +28,7 @@ public class Attributes {
                 attribute.addCDNAttribute(parent, context);
             } else if (attribute.isDynamic()) {
                 if (attribute.isDynamicBooleanAttribute()) attribute.addBooleanAttribute(parent, context);
+                else if (attribute.isDynamicMetaAttribute()) attribute.addMetaAttribute(parent, context);
                 else attribute.addValueAttribute(parent, context);
             } else if (attribute.isMessage()) {
                 attribute.addMessageAttribute(parent, context);
@@ -42,12 +42,12 @@ public class Attributes {
         String name = attribute.name;
 
         if ("xmlns:c".equals(name) || "xmlns:m".equals(name)
-            || "c:text".equals(name)
-            || "c:html".equals(name)
-            || "m:text".equals(name)
-            || "c:include".equals(name)
-            || "c:for".equals(name)
-            || "c:if".equals(name))
+                || "c:text".equals(name)
+                || "c:html".equals(name)
+                || "m:text".equals(name)
+                || "c:include".equals(name)
+                || "c:for".equals(name)
+                || "c:if".equals(name))
             return true;
 
         return !attribute.isDynamic() && (attributes.containsKey("c:" + name) || attributes.containsKey("m:" + name));   // there is dynamic attribute to overwrite
@@ -55,9 +55,9 @@ public class Attributes {
 
     public boolean containDynamicContent() {
         return attributes.containsKey("c:text")
-            || attributes.containsKey("m:text")
-            || attributes.containsKey("c:html")
-            || attributes.containsKey("c:include");
+                || attributes.containsKey("m:text")
+                || attributes.containsKey("c:html")
+                || attributes.containsKey("c:include");
     }
 
     public Attribute dynamicContentAttribute() {
@@ -88,6 +88,8 @@ public class Attributes {
         attribute = attributes.get("c:html");
         if (attribute != null) count++;
         attribute = attributes.get("c:include");
+        if (attribute != null) count++;
+        attribute = attributes.get("c:content");
         if (attribute != null) count++;
 
         if (count > 1 && attribute != null)


### PR DESCRIPTION
Hi, Neo.

Currently if you try to add a meta property containing a dynamic url, it will be escaped, so the meta tag won't be parsed as expected by crawlers.

I did a small change to support urls within meta tags, please check and let me know your comments.