### PR TITLE
UTF-8 as default encoding for JSON (RFC-7159#sectio-8.1)

### DIFF
--- a/core-ng/src/main/java/core/framework/http/ContentType.java
+++ b/core-ng/src/main/java/core/framework/http/ContentType.java
@@ -22,7 +22,8 @@ public final class ContentType {
     public static final ContentType TEXT_CSS = create("text/css", UTF_8);
     public static final ContentType TEXT_PLAIN = create("text/plain", UTF_8);
     public static final ContentType TEXT_XML = create("text/xml", UTF_8);
-    public static final ContentType APPLICATION_JSON = create("application/json", UTF_8);
+    // UTF-8 as default encoding for JSON (RFC-7159#sectio-8.1), refer to https://chromium-review.googlesource.com/c/chromium/src/+/587829
+    public static final ContentType APPLICATION_JSON = create("application/json", null);
     public static final ContentType APPLICATION_JAVASCRIPT = create("application/javascript", UTF_8);
     // form body content type doesn't use charset normally, refer to https://www.w3.org/TR/html5/sec-forms.html#urlencoded-form-data
     public static final ContentType APPLICATION_FORM_URLENCODED = create("application/x-www-form-urlencoded", null);

--- a/core-ng/src/main/java/core/framework/internal/web/service/WebServiceClient.java
+++ b/core-ng/src/main/java/core/framework/internal/web/service/WebServiceClient.java
@@ -129,7 +129,7 @@ public class WebServiceClient {
 
         // handle empty body gracefully, e.g. 503 during deployment
         // handle html error message gracefully, e.g. public cloud LB failed to connect to backend
-        if (response.body.length > 0 && ContentType.APPLICATION_JSON.equals(response.contentType)) {
+        if (response.body.length > 0 && ContentType.APPLICATION_JSON.mediaType.equals(response.contentType.mediaType)) {
             ErrorResponse error = errorResponse(response);
             if (error.id != null && error.errorCode != null) {  // use manual validation rather than annotation to keep the flow straightforward and less try/catch, check if valid error response json
                 LOGGER.debug("failed to call remote service, statusCode={}, id={}, severity={}, errorCode={}, remoteStackTrace={}", statusCode, error.id, error.severity, error.errorCode, error.stackTrace);

--- a/core-ng/src/test/java/core/framework/http/ContentTypeTest.java
+++ b/core-ng/src/test/java/core/framework/http/ContentTypeTest.java
@@ -12,9 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ContentTypeTest {
     @Test
     void parse() {
-        ContentType type = ContentType.parse("application/json; charset=utf-8");    // within cache
+        ContentType type = ContentType.parse("application/json");    // within cache
         assertThat(type.mediaType).isEqualTo("application/json");
-        assertThat(type.charset()).get().isEqualTo(StandardCharsets.UTF_8);
+        assertThat(type.charset()).isEmpty();
 
         type = ContentType.parse("application/javascript; charset=utf-8");    // not in cache
         assertThat(type.mediaType).isEqualTo("application/javascript");
@@ -35,7 +35,7 @@ class ContentTypeTest {
 
     @Test
     void value() {
-        assertThat(ContentType.APPLICATION_JSON.toString()).isEqualTo("application/json; charset=utf-8");
+        assertThat(ContentType.APPLICATION_JSON.toString()).isEqualTo("application/json");
         assertThat(ContentType.APPLICATION_OCTET_STREAM.toString()).isEqualTo("application/octet-stream");
     }
 
@@ -54,7 +54,7 @@ class ContentTypeTest {
 
     @Test
     void compare() {
-        assertThat(ContentType.APPLICATION_JSON).isEqualTo(ContentType.parse("application/json; charset=utf-8"));
+        assertThat(ContentType.APPLICATION_JSON).isEqualTo(ContentType.parse("application/json"));
         assertThat(ContentType.APPLICATION_JSON.hashCode()).isNotEqualTo(ContentType.TEXT_HTML.hashCode());
     }
 }

--- a/core-ng/src/test/java/core/framework/internal/web/service/WebServiceClientTest.java
+++ b/core-ng/src/test/java/core/framework/internal/web/service/WebServiceClientTest.java
@@ -114,7 +114,7 @@ class WebServiceClientTest {
 
     @Test
     void validateResponseWith410() {
-        assertThatThrownBy(() -> webServiceClient.validateResponse(new HTTPResponse(HTTPStatus.GONE.code, Map.of(), Strings.bytes("{}"))))
+        assertThatThrownBy(() -> webServiceClient.validateResponse(new HTTPResponse(HTTPStatus.GONE.code, Map.of(HTTPHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString()), Strings.bytes("{}"))))
                 .isInstanceOf(RemoteServiceException.class)
                 .satisfies(throwable -> {
                     RemoteServiceException exception = (RemoteServiceException) throwable;


### PR DESCRIPTION
UTF-8 as default encoding for JSON (RFC-7159#sectio-8.1), refer to https://chromium-review.googlesource.com/c/chromium/src/+/587829