### PR TITLE
Add jdk.naming.dns module to support mongodb+srv connections.

### DIFF
--- a/docker/jre/Dockerfile
+++ b/docker/jre/Dockerfile
@@ -1,5 +1,5 @@
 FROM        eclipse-temurin:17.0.1_12-jdk-alpine as build
-RUN         jlink --add-modules java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management.rmi,java.naming,java.security.jgss,java.security.sasl,java.sql,java.xml \
+RUN         jlink --add-modules java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management.rmi,java.naming,jdk.naming.dns,java.security.jgss,java.security.sasl,java.sql,java.xml \
                   --add-modules jdk.charsets,jdk.crypto.cryptoki,jdk.jdi,jdk.localedata,jdk.management.jfr,jdk.naming.rmi,jdk.net,jdk.unsupported \
                   --output /opt/jre --strip-java-debug-attributes --no-man-pages --no-header-files --compress=2
 


### PR DESCRIPTION
Currently if you use a mongodb+srv connection string, it will fail with the following exception:
com.mongodb.MongoClientException: Unable to support mongodb+srv// style connections as the ‘com.sun.jndi.dns.DnsContextFactory’ class is not available in this JRE. A JNDI context is required for resolving SRV records.

Adding the jdk.naming.dns module fixes the issue.