### PR TITLE
* mongo: support readPreference in findOne

### DIFF
--- a/core-ng-mongo/src/main/java/core/framework/mongo/impl/MongoCollectionImpl.java
+++ b/core-ng-mongo/src/main/java/core/framework/mongo/impl/MongoCollectionImpl.java
@@ -132,7 +132,7 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
         int returnedDocs = 0;
         try {
             List<T> results = new ArrayList<>(2);
-            FindIterable<T> query = collection()
+            FindIterable<T> query = collection(findOne.readPreference)
                 .find(filter)
                 .limit(2)
                 .maxTime(mongo.timeoutInMs, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
This pull request makes a targeted improvement to the `findOne` method in `MongoCollectionImpl.java` by ensuring that the collection is accessed with the correct read preference specified in the `FindOne` parameter. This helps ensure that read operations can be directed to the appropriate MongoDB replica set member as needed.

* [`core-ng-mongo/src/main/java/core/framework/mongo/impl/MongoCollectionImpl.java`](diffhunk://#diff-48f29e38394abb8ce31d60d96313a56d441144590ebe8322696137f39bc34f1cL135-R135): Updated the `findOne` method to use the `readPreference` from the `FindOne` object when accessing the collection.